### PR TITLE
Add Category in the .toc file (why not ?)

### DIFF
--- a/iPMythicTimer.toc
+++ b/iPMythicTimer.toc
@@ -8,6 +8,17 @@
 ## SavedVariables: IPMTDB, IPMTOptions, IPMTDungeon, IPMTTheme
 ## X-eMail: ipzaur@gmail.com
 ## IconTexture: Interface\AddOns\iPMythicTimer\media\icon.png
+## Category-enUS: Mythic+ Dungeons
+## Category-deDE: Mythic+ Dungeons
+## Category-esES: Mythic+ Dungeons
+## Category-esMX: Mythic+ Dungeons
+## Category-frFR: Donjons Mythique+
+## Category-itIT: Mythic+ Dungeons
+## Category-koKR: Mythic+ Dungeons
+## Category-ptBR: Mythic+ Dungeons
+## Category-ruRU: Подземелья М+
+## Category-zhCN: Mythic+ Dungeons
+## Category-zhTW: Mythic+ Dungeons
 
 Localization\localization.lua
 Localization\localization_ru.lua


### PR DESCRIPTION
Почему бы не добавить категорию ? Щас вроде почти все так делают. Только вот вопрос: есть якобы встроенная в игру категория "Подземелья и рейды", но если аддон связан непосредственно с ключами М+, то можно и оставить Mythic+ категорию ?!